### PR TITLE
opendatasoft.py: Add timezone arg

### DIFF
--- a/bonobo/ext/opendatasoft.py
+++ b/bonobo/ext/opendatasoft.py
@@ -20,11 +20,12 @@ class OpenDataSoftAPI(Configurable):
     netloc = Option(str, default='data.opendatasoft.com')
     path = Option(path_str, default='/api/records/1.0/search/')
     rows = Option(int, default=100)
+    timezone = Option(str, default='Europe/Paris')
     kwargs = Option(dict, default=dict)
 
     @ContextProcessor
     def compute_path(self, context):
-        params = (('dataset', self.dataset), ('rows', self.rows), ) + tuple(sorted(self.kwargs.items()))
+        params = (('dataset', self.dataset), ('rows', self.rows), ('timezone', self.timezone)) + tuple(sorted(self.kwargs.items()))
         yield self.endpoint.format(scheme=self.scheme, netloc=self.netloc, path=self.path) + '?' + urlencode(params)
 
     @ContextProcessor


### PR DESCRIPTION
The timezone argument is needed for bonobo/examples/fablabs.py
to properly run.

Fixes https://github.com/python-bonobo/bonobo/issues/22