### PR TITLE
Fix #113. Add flush() method to IOBuffer

### DIFF
--- a/bonobo/ext/console.py
+++ b/bonobo/ext/console.py
@@ -23,6 +23,9 @@ class IOBuffer():
         finally:
             previous.close()
 
+    def flush(self):
+        self.current.flush()
+
 
 class ConsoleOutputPlugin(Plugin):
     """


### PR DESCRIPTION
Addresses issue #113 
Implements `IOBuffer().flush()` method.