### PR TITLE
Do not fail in ipykernel without ipywidgets.

### DIFF
--- a/bonobo/_api.py
+++ b/bonobo/_api.py
@@ -1,3 +1,5 @@
+import logging
+
 from bonobo.structs import Bag, Graph, Token
 from bonobo.nodes import CsvReader, CsvWriter, FileReader, FileWriter, Filter, JsonReader, JsonWriter, Limit, \
     PrettyPrinter, PickleWriter, PickleReader, RateLimited, Tee, count, identity, noop
@@ -52,9 +54,14 @@ def run(graph, strategy=None, plugins=None, services=None):
                 plugins.append(ConsoleOutputPlugin)
 
         if _is_jupyter_notebook():
-            from bonobo.ext.jupyter import JupyterOutputPlugin
-            if JupyterOutputPlugin not in plugins:
-                plugins.append(JupyterOutputPlugin)
+            try:
+                from bonobo.ext.jupyter import JupyterOutputPlugin
+            except ImportError:
+                logging.warning(
+                    'Failed to load jupyter widget. Easiest way is to install the optional "jupyter" ' 'dependencies with «pip install bonobo[jupyter]», but you can also install a specific ' 'version by yourself.')
+            else:
+                if JupyterOutputPlugin not in plugins:
+                    plugins.append(JupyterOutputPlugin)
 
     return strategy.execute(graph, plugins=plugins, services=services)
 

--- a/bonobo/ext/jupyter/plugin.py
+++ b/bonobo/ext/jupyter/plugin.py
@@ -1,11 +1,11 @@
+import logging
+
 from bonobo.ext.jupyter.widget import BonoboWidget
 from bonobo.plugins import Plugin
 
 try:
     import IPython.core.display
 except ImportError as e:
-    import logging
-
     logging.exception(
         'You must install Jupyter to use the bonobo Jupyter extension. Easiest way is to install the '
         'optional "jupyter" dependencies with «pip install bonobo[jupyter]», but you can also install a '


### PR DESCRIPTION
Currently, widget for jupyter expects that `ipywidgets` is installed in current env. If you do not have `ipywidgets` installed (e.g. using your env only as a kernel) then it would fail at this import https://github.com/python-bonobo/bonobo/blob/develop/bonobo/ext/jupyter/widget.py#L1
This fix will log a warning instead.