### PR TITLE
Check if PluginExecutionContext was started before shutting it down.

### DIFF
--- a/bonobo/execution/plugin.py
+++ b/bonobo/execution/plugin.py
@@ -16,8 +16,9 @@ class PluginExecutionContext(LoopingExecutionContext):
             self.wrapped.initialize()
 
     def shutdown(self):
-        with recoverable(self.handle_error):
-            self.wrapped.finalize()
+        if self.started:
+            with recoverable(self.handle_error):
+                self.wrapped.finalize()
         self.alive = False
 
     def step(self):


### PR DESCRIPTION
If a `PluginExecutionContext().shutdown()` is called _before_
`PluginExecutionContext().start()` was called,
this leads to an `AttributeError` exception since finalizer tries to
access to attributes which were never defined.

```
AttributeError (in ConsoleOutputPlugin)
 | 'ConsoleOutputPlugin' object has no attribute 'prefix'
 | 
 | Traceback (most recent call last):
 |   File "/Users/vvokhmin/src/ep17/bonobo/bonobo/execution/base.py", line 15, in recoverable
 |     yield
 |   File "/Users/vvokhmin/src/ep17/bonobo/bonobo/execution/plugin.py", line 20, in shutdown
 |     self.wrapped.finalize()
 |   File "/Users/vvokhmin/src/ep17/bonobo/bonobo/ext/console.py", line 56, in finalize
 |     self._write(self.context.parent, rewind=False)
 |   File "/Users/vvokhmin/src/ep17/bonobo/bonobo/ext/console.py", line 113, in _write
 |     self.write(graph_context, prefix=self.prefix, append=append, rewind=rewind)
 | AttributeError: 'ConsoleOutputPlugin' object has no attribute 'prefix'
```