### PR TITLE
More readable statistics on Ubuntu workstation standard terminal

### DIFF
--- a/bonobo/ext/console.py
+++ b/bonobo/ext/console.py
@@ -79,7 +79,7 @@ class ConsoleOutputPlugin(Plugin):
             else:
                 _line = ''.join(
                     (
-                        ' ', Fore.BLACK, '-', ' ', node.name, name_suffix, ' ', node.get_statistics_as_string(),
+                        ' ', Fore.GREEN, '-', ' ', node.name, name_suffix, ' ', node.get_statistics_as_string(),
                         Style.RESET_ALL, ' ',
                     )
                 )


### PR DESCRIPTION
statistics are hard to read on the Ubuntu standard terminal that has a dark purple background. See issue #165