### PR TITLE
Inspect: Making id invisible

### DIFF
--- a/bonobo/commands/inspect.py
+++ b/bonobo/commands/inspect.py
@@ -7,7 +7,9 @@ from bonobo.util.objects import get_name
 OUTPUT_GRAPHVIZ = 'graphviz'
 
 def _ident(graph, i):
-	return json.dumps('{} [label="{}"]'.format(str(i),get_name(graph[i])))
+	escaped_index = str(i)
+	escaped_name = json.dumps(get_name(graph[i]))
+	return '{{{} [label={}]}}'.format(escaped_index,escaped_name)
 
 def execute(*, output, **kwargs):
     graph, plugins, services = read(**kwargs)

--- a/bonobo/commands/inspect.py
+++ b/bonobo/commands/inspect.py
@@ -7,7 +7,7 @@ from bonobo.util.objects import get_name
 OUTPUT_GRAPHVIZ = 'graphviz'
 
 def _ident(graph, i):
-    return json.dumps(get_name(graph[i])+' ('+str(i)+')')
+	return json.dumps('{} [label="{}"]'.format(str(i),get_name(graph[i])))
 
 def execute(*, output, **kwargs):
     graph, plugins, services = read(**kwargs)


### PR DESCRIPTION
Removingd bonobo id from graphviz label so that graphs show clean names

example:
digraph {
  rankdir = LR;
  "BEGIN" [shape="point"];
  "BEGIN" -> {0 [label="A"]};
  {0 [label="A"]} -> {1 [label="B"]};
  {1 [label="B"]} -> {2 [label="A"]};
}
