### PR TITLE
Issue #134: add a `bonobo download url` command

### DIFF
--- a/Projectfile
+++ b/Projectfile
@@ -34,6 +34,7 @@ python.setup(
             'inspect = bonobo.commands.inspect:register',
             'run = bonobo.commands.run:register',
             'version = bonobo.commands.version:register',
+            'download = bonobo.commands.download:register',
         ],
     }
 )

--- a/bonobo/commands/download.py
+++ b/bonobo/commands/download.py
@@ -1,0 +1,43 @@
+import io
+import re
+import urllib.request
+
+import bonobo
+
+EXAMPLES_BASE_URL = 'https://raw.githubusercontent.com/python-bonobo/bonobo/master/bonobo/examples/'
+"""The URL to our git repository, in raw mode."""
+
+
+def _save_stream(fin, fout):
+    """Read the input stream and write it to the output stream block-by-block."""
+    while True:
+        data = fin.read(io.DEFAULT_BUFFER_SIZE)
+        if data:
+            fout.write(data)
+        else:
+            break
+
+
+def _open_url(url):
+    """Open a HTTP connection to the URL and return a file-like object."""
+    response = urllib.request.urlopen(url)
+    if response.getcode() != 200:
+        raise IOError('unable to download {}, HTTP {}'.format(url, response.getcode()))
+    return response
+
+
+def execute(path, *args, **kwargs):
+    path = path.lstrip('/')
+    if not path.startswith('examples'):
+        raise ValueError('download command currently supports examples only')
+    examples_path = re.sub('^examples/', '', path)
+    output_path = bonobo.get_examples_path(examples_path)
+    fin = _open_url(EXAMPLES_BASE_URL + examples_path)
+    with open(output_path, 'wb') as fout:
+        _save_stream(fin, fout)
+    print('saved to {}'.format(output_path))
+
+
+def register(parser):
+    parser.add_argument('path', help='The relative path of the thing to download.')
+    return execute

--- a/bonobo/commands/download.py
+++ b/bonobo/commands/download.py
@@ -29,8 +29,7 @@ def execute(path, *args, **kwargs):
         raise ValueError('download command currently supports examples only')
     examples_path = re.sub('^examples/', '', path)
     output_path = bonobo.get_examples_path(examples_path)
-    response = _open_url(EXAMPLES_BASE_URL + examples_path)
-    with open(output_path, 'wb') as fout:
+    with _open_url(EXAMPLES_BASE_URL + examples_path) as response, open(output_path, 'wb') as fout:
         _write_response(response, fout)
     print('saved to {}'.format(output_path))
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Unreleased
+::::::::::
+
+New features
+------------
+
+Command line
+............
+
+* `bonobo download /examples/datasets/coffeeshops.txt` now downloads the coffeeshops example
+
 v.0.5.0 - 5 october 2017
 ::::::::::::::::::::::::
 

--- a/docs/tutorial/tut02.rst
+++ b/docs/tutorial/tut02.rst
@@ -59,13 +59,7 @@ available in **Bonobo**'s repository:
 
 .. code-block:: shell-session
 
-    $ curl https://raw.githubusercontent.com/python-bonobo/bonobo/master/bonobo/examples/datasets/coffeeshops.txt > `python3 -c 'import bonobo; print(bonobo.get_examples_path("datasets/coffeeshops.txt"))'`
-
-.. note::
-
-    The "example dataset download" step will be easier in the future.
-
-    https://github.com/python-bonobo/bonobo/issues/134
+    $ bonobo download examples/datasets/coffeeshops.txt
 
 .. literalinclude:: ../../bonobo/examples/tutorials/tut02e01_read.py
     :language: python

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,8 @@ setup(
         'bonobo.commands': [
             'convert = bonobo.commands.convert:register', 'init = bonobo.commands.init:register',
             'inspect = bonobo.commands.inspect:register', 'run = bonobo.commands.run:register',
-            'version = bonobo.commands.version:register'
+            'version = bonobo.commands.version:register',
+            'download = bonobo.commands.download:register',
         ],
         'console_scripts': ['bonobo = bonobo.commands:entrypoint']
     },

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -164,6 +164,12 @@ def test_download_works_for_examples(runner):
         def iter_content(self, *args, **kwargs):
             return [expected_bytes]
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args, **kwargs):
+            pass
+
     fout = io.BytesIO()
     fout.close = lambda: None
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -13,6 +13,7 @@ from cookiecutter.exceptions import OutputDirExistsException
 from bonobo import __main__, __version__, get_examples_path
 from bonobo.commands import entrypoint
 from bonobo.commands.run import DEFAULT_GRAPH_FILENAMES
+from bonobo.commands.download import EXAMPLES_BASE_URL
 
 
 def runner(f):
@@ -150,6 +151,29 @@ def test_version(runner):
     out = out.strip()
     assert out.startswith('bonobo ')
     assert __version__ in out
+
+
+@all_runners
+def test_download_works_for_examples(runner):
+    fout = io.BytesIO()
+    fout.close = lambda: None
+
+    expected_bytes = b'hello world'
+    with patch('bonobo.commands.download._open_url') as mock_open_url, \
+            patch('bonobo.commands.download.open') as mock_open:
+        mock_open_url.return_value = io.BytesIO(expected_bytes)
+        mock_open.return_value = fout
+        runner('download', 'examples/datasets/coffeeshops.txt')
+    expected_url = EXAMPLES_BASE_URL + 'datasets/coffeeshops.txt'
+    mock_open_url.assert_called_once_with(expected_url)
+
+    assert fout.getvalue() == expected_bytes
+
+
+@all_runners
+def test_download_fails_non_example(runner):
+    with pytest.raises(ValueError):
+        runner('download', '/something/entirely/different.txt')
 
 
 @all_runners


### PR DESCRIPTION
This enables users on different platforms to download the examples in
the tutorial using the same command.