### PR TITLE
Tweaks to ETLCommand command

### DIFF
--- a/bonobo/contrib/django/commands.py
+++ b/bonobo/contrib/django/commands.py
@@ -41,6 +41,9 @@ class ETLCommand(BaseCommand):
     def get_services(self):
         return {}
 
+    def get_strategy(self):
+        return None
+
     def info(self, *args, **kwargs):
         self.logger.info(*args, **kwargs)
 
@@ -48,6 +51,7 @@ class ETLCommand(BaseCommand):
         results = []
         with bonobo.parse_args(options) as options:
             services = self.get_services()
+            strategy = self.get_strategy()
             graph_coll = self.get_graph(*args, **options)
 
             if not isinstance(graph_coll, GeneratorType):
@@ -56,7 +60,7 @@ class ETLCommand(BaseCommand):
             for i, graph in enumerate(graph_coll):
                 assert isinstance(graph, bonobo.Graph), 'Invalid graph provided.'
                 print(term.lightwhite('{}. {}'.format(i + 1, graph.name)))
-                result = bonobo.run(graph, services=services)
+                result = bonobo.run(graph, services=services, strategy=strategy)
                 results.append(result)
                 print(term.lightblack(' ... return value: ' + str(result)))
                 print()

--- a/bonobo/contrib/django/commands.py
+++ b/bonobo/contrib/django/commands.py
@@ -44,13 +44,7 @@ class ETLCommand(BaseCommand):
     def info(self, *args, **kwargs):
         self.logger.info(*args, **kwargs)
 
-    def handle(self, *args, **options):
-        _stdout_backup, _stderr_backup = self.stdout, self.stderr
-
-        self.stdout = OutputWrapper(ConsoleOutputPlugin._stdout, ending=CLEAR_EOL + '\n')
-        self.stderr = OutputWrapper(ConsoleOutputPlugin._stderr, ending=CLEAR_EOL + '\n')
-        self.stderr.style_func = lambda x: Fore.LIGHTRED_EX + Back.RED + '!' + Style.RESET_ALL + ' ' + x
-
+    def run(self, *args, **options):
         with bonobo.parse_args(options) as options:
             services = self.get_services()
             graph_coll = self.get_graph(*args, **options)
@@ -64,5 +58,14 @@ class ETLCommand(BaseCommand):
                 result = bonobo.run(graph, services=services)
                 print(term.lightblack(' ... return value: ' + str(result)))
                 print()
+
+    def handle(self, *args, **options):
+        _stdout_backup, _stderr_backup = self.stdout, self.stderr
+
+        self.stdout = OutputWrapper(ConsoleOutputPlugin._stdout, ending=CLEAR_EOL + '\n')
+        self.stderr = OutputWrapper(ConsoleOutputPlugin._stderr, ending=CLEAR_EOL + '\n')
+        self.stderr.style_func = lambda x: Fore.LIGHTRED_EX + Back.RED + '!' + Style.RESET_ALL + ' ' + x
+
+        self.run(*args, **kwargs)
 
         self.stdout, self.stderr = _stdout_backup, _stderr_backup

--- a/bonobo/contrib/django/commands.py
+++ b/bonobo/contrib/django/commands.py
@@ -45,6 +45,7 @@ class ETLCommand(BaseCommand):
         self.logger.info(*args, **kwargs)
 
     def run(self, *args, **options):
+        results = []
         with bonobo.parse_args(options) as options:
             services = self.get_services()
             graph_coll = self.get_graph(*args, **options)
@@ -56,8 +57,11 @@ class ETLCommand(BaseCommand):
                 assert isinstance(graph, bonobo.Graph), 'Invalid graph provided.'
                 print(term.lightwhite('{}. {}'.format(i + 1, graph.name)))
                 result = bonobo.run(graph, services=services)
+                results.append(result)
                 print(term.lightblack(' ... return value: ' + str(result)))
                 print()
+
+        return results
 
     def handle(self, *args, **options):
         _stdout_backup, _stderr_backup = self.stdout, self.stderr


### PR DESCRIPTION
This allows for a couple things:

1. The ability to override the run function and capture the result of the run without having to override the entire handle function
2. Allows for the user to override the default strategy if they choose (for me the strategy is set as a django setting depending on environment, dev vs. prod)

Best read commit by commit.

@hartym I wasn't sure how to run this code, do you have a way of testing this, or do you spin up a django project and link the pip library to it? Note: This code hasn't been run