### PR TITLE
Explicitly test results for None is safer and correct

### DIFF
--- a/bonobo/execution/contexts/node.py
+++ b/bonobo/execution/contexts/node.py
@@ -174,7 +174,7 @@ class NodeExecutionContext(BaseContext, WithStatistics):
                 else:
                     # Push data (in case of an iterator)
                     self._put(self._cast(input_bag, result))
-        elif results:
+        elif results is not None:
             # Push data (returned value)
             self._put(self._cast(input_bag, results))
         else:

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -43,7 +43,7 @@ def test_execution():
     strategy = NaiveStrategy()
     ctx = strategy.execute(graph)
 
-    assert ctx.results == [1, 4, 9, 16, 25, 36, 49, 64, 81]
+    assert ctx.results == [0, 1, 4, 9, 16, 25, 36, 49, 64, 81]
 
 
 def test_simple_execution_context():


### PR DESCRIPTION
Using the truth value is ambiguous and does not work for zero.