### PR TITLE
Exit 1 if any node failed to run

### DIFF
--- a/bonobo/_api.py
+++ b/bonobo/_api.py
@@ -87,7 +87,12 @@ def run(graph, *, plugins=None, services=None, strategy=None):
         graph = graph.graph
 
     with sweeten_errors():
-        return strategy.execute(graph, plugins=plugins, services=services)
+        ctx = strategy.execute(graph, plugins=plugins, services=services)
+
+        if any(n.statistics['err'] for n in ctx.nodes):
+            exit(1)
+
+        return ctx
 
 
 def _inspect_as_graph(graph):

--- a/tests/test_basicusage.py
+++ b/tests/test_basicusage.py
@@ -15,3 +15,12 @@ def test_run_graph_noop():
         result = bonobo.run(graph)
 
     assert isinstance(result, GraphExecutionContext)
+
+
+def test_run_graph_failed():
+    graph = bonobo.Graph(lambda: 1/0)
+    assert len(graph) == 1
+
+    with pytest.raises(SystemExit):
+        with patch("bonobo._api._is_interactive_console", side_effect=lambda: False):
+            bonobo.run(graph)


### PR DESCRIPTION
This is useful for CLI chaining or to indicate the failure programmatically to caller