### PR TITLE
Change Graph.__getitem__ to shorthand for get_cursor

### DIFF
--- a/bonobo/structs/graphs.py
+++ b/bonobo/structs/graphs.py
@@ -102,8 +102,8 @@ class Graph:
         """
         return len(self.nodes)
 
-    def __getitem__(self, key):
-        return self.nodes[key]
+    def __getitem__(self, ref):
+        return self.get_cursor(ref)
 
     def __enter__(self):
         return self.get_cursor().__enter__()


### PR DESCRIPTION
currently `Graph.__getitem__()`  is implemented as:
```python
def __getitem__(self, key):
    return self.nodes[key]
```
which makes sense... but it only saves about 6 characters of typing `graph[a]` vs `graph.nodes[a]`. However... one thing that's kind of clunky is:
```python
graph >> a >> b >> c
graph.get_cursor(a) >> d >> e    # adds nodes that receive data from a
```
If `Graph.__getitem__()` was reimplemented as a shorthand for `Graph.get_cursor()`, the above example could be reduced to:
```python
graph >> a >> b >> c
graph[a] >> d >> e
```
which I think is much much cleaner and more intuitive. It saves time typing `get_cursor()` (which users will be doing much more often than retrieving nodes by their numerical index) and is also easier to read. It may even be possible this way to hide the existence of the `GraphCursor` class from top-level API's entirely.
Obviously this would be a breaking change, but it would be a very simple matter to regex find and replace `graph\[(.+)\]` with `graph\.nodes\[$1\]`.

As a bonus, this could also eliminate the need for the `Graph.orphan()` method, since one could simply call `graph[None]` to achieve the same functionality.