### PR TITLE
docs: fix simple typo, runnning -> running

### DIFF
--- a/bonobo/errors.py
+++ b/bonobo/errors.py
@@ -30,7 +30,7 @@ class ConfigurationError(Exception):
 
 class UnrecoverableError(Exception):
     """Flag for errors that must interrupt the workflow, either because they will happen for sure on each node run, or
-    because you know that your transformation has no point continuing runnning after a bad event."""
+    because you know that your transformation has no point continuing running after a bad event."""
 
 
 class AbstractError(UnrecoverableError, NotImplementedError):


### PR DESCRIPTION
There is a small typo in bonobo/errors.py.

Should read `running` rather than `runnning`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md