### PR TITLE
python 3.10 fix

### DIFF
--- a/bonobo/contrib/django/commands.py
+++ b/bonobo/contrib/django/commands.py
@@ -78,6 +78,6 @@ class ETLCommand(BaseCommand):
         self.stderr.style_func = lambda x: Fore.LIGHTRED_EX + Back.RED + "!" + Style.RESET_ALL + " " + x
 
         try:
-            return self.run(*args, **options)
+            self.run(*args, **options)
         finally:
             self.stdout, self.stderr = _stdout_backup, _stderr_backup

--- a/bonobo/util/collections.py
+++ b/bonobo/util/collections.py
@@ -1,6 +1,6 @@
 import bisect
 import functools
-from collections import Sequence
+from collections.abc import Sequence
 
 
 class sortedlist(list):


### PR DESCRIPTION
Minor fix for a python 3.10 issue: `Sequence` was moved from `collections` to `collections.abc`, so an import has to be changed.